### PR TITLE
Fixing image links problem

### DIFF
--- a/src/main/java/com/teamtreehouse/countries/controller/CountriesController.java
+++ b/src/main/java/com/teamtreehouse/countries/controller/CountriesController.java
@@ -24,7 +24,7 @@ public class CountriesController {
 		return "index";
 	}
 	
-	@RequestMapping("/flags/{countryName}")
+	@RequestMapping("/country/{countryName}")
 	public String findByCountry(@PathVariable String countryName,ModelMap modelMap){
 		Country listByName=countryRepository.findByName(countryName);
 		modelMap.put("country",listByName);

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -14,7 +14,7 @@
 	</header>
 	<div class="container">
 		<div th:each="country : ${countries}" class="country">
-			    <a th:href="@{'/flags/'+${country.countryImageName}}">
+			    <a th:href="@{'/country/'+${country.countryImageName}}">
 			    <img th:src="@{'/flags/'+${country.countryImageName}+'.png'}" th:alt="@{${country.countryImageName}+'.png'}"/>
 				<h4 th:text="${country.countryName}">India</h4>
 			</a>


### PR DESCRIPTION
[For you Treehouse question](https://teamtreehouse.com/community/countries-of-the-world-with-spring-flag-images-not-showing)

So the problem is with the naming convention.

Because you write @RequestMapping("/flags/{countryName}") and use path to images "/flags/india.png"

Spring is confused where is the asset, i.e. image and where is actual link to detail page.

I changed link to "/country". Does it make sense ?

P.S. In later courses you see that for example Chris puts all static stuff under "/assets" folder to avoid confusions